### PR TITLE
Add Google Drive scope as default

### DIFF
--- a/dist/plugin.json
+++ b/dist/plugin.json
@@ -29,7 +29,7 @@
       "path": "bigquery",
       "url": "https://www.googleapis.com/bigquery",
       "jwtTokenAuth": {
-        "scopes": ["https://www.googleapis.com/auth/bigquery"],
+        "scopes": ["https://www.googleapis.com/auth/bigquery", "https://www.googleapis.com/auth/drive"],
         "params": {
           "token_uri": "{{.JsonData.tokenUri}}",
           "client_email": "{{.JsonData.clientEmail}}",


### PR DESCRIPTION
First of all, thanks for this plugin - really great job!

**What this PR does / why we need it**: This PR adds Google Drive scope to the service account used for the plugin. This is useful when service account queries BigQuery table that uses Google Sheets as a source. 

**Which issue(s) this PR fixes**: N/A

**Special notes for your reviewer**: This might be better implemented as a parameter to specify during plugin configuration. 

**Release note**:
```release-note
* Add Google Drive scope
```
