### PR TITLE
Fixed syntax error because of additional bracket

### DIFF
--- a/src/bigquery_query.ts
+++ b/src/bigquery_query.ts
@@ -582,7 +582,7 @@ export default class BigQueryQuery {
     } else {
       return q.replace(
         /\$__timeGroup\(([\w_.]+,+[a-zA-Z0-9_ ]+.*\))/g,
-        intervalStr + ")"
+        intervalStr
       );
     }
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/doitintl/bigquery-grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If the PR is unfinished, mark it as a draft PR.
4. Rebase your PR if it gets out of sync with master
-->

**What this PR does / why we need it**:
Fixed issue with a additional bracket which causes a syntax error

**Which issue(s) this PR fixes**:
```
SELECT
  $__timeGroup(timestamp, '1h') AS time,
  CAST (`jsonPayload`.`ddd`AS String ) AS metric,
  COUNT(*) as count
FROM `asd.asd`
WHERE
  $__timeFilter(timestamp)
GROUP BY
  $__timeGroup(timestamp, '1h'),
  `jsonPayload`.`dddd`
```

Turns into 
```
  SELECT
    TIMESTAMP_SECONDS(DIV(UNIX_SECONDS(`timestamp`), 0) * 0)) AS time,
    CAST (`jsonPayload`.`ddd`AS String ) AS metric,
    COUNT(*) as count
  FROM `asd.asd`
  WHERE
    `timestamp` BETWEEN TIMESTAMP_MILLIS (1574920055270) AND TIMESTAMP_MILLIS (1574930855271)
  GROUP BY
    TIMESTAMP_SECONDS(DIV(UNIX_SECONDS(`timestamp`), 0) * 0)),
    `jsonPayload`.`ddd`
   LIMIT 1260
```

which causes a `Syntax error: Unexpected ")" at [2:59]`

**Special notes for your reviewer**:

**Release note**:
<!--
If this is a user facing change and should be mentioned in release note add it below. If no, just write "NONE" below.
-->
```release-note
Fixed issue with a additional bracket which causes a syntax error using the $__timeGroup macro
```
