### PR TITLE
Fix GCE service account scope instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If Grafana is running on a Google Compute Engine (GCE) virtual machine, it is po
 
 1. First of all, you need to create a Service Account that can be used by the GCE virtual machine. See detailed instructions on how to do that [here](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances#createanewserviceaccount).
 2. Make sure the GCE virtual machine instance is being run as the service account that you just created. See instructions [here](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances#using).
-3. Allow access to the `Stackdriver Monitoring API` scope. See instructions [here](changeserviceaccountandscopes).
+3. Allow access to the `BigQuery API` scope. See instructions [here](changeserviceaccountandscopes).
 
 Read more about creating and enabling service accounts for GCE VM instances [here](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances).
 


### PR DESCRIPTION
Probably the typo comes from copy/pasting this part of the readme from the grafana stackdriver datasource docs.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/doitintl/bigquery-grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If the PR is unfinished, mark it as a draft PR.
4. Rebase your PR if it gets out of sync with master
-->

**What this PR does / why we need it**:
A simple error in the docs where you need to provide access to the service account on GCE to access the big query api.