### PR TITLE
support space in __timeGroupXxx argument

### DIFF
--- a/src/bigquery_query.ts
+++ b/src/bigquery_query.ts
@@ -43,8 +43,8 @@ export default class BigQueryQuery {
       ? q.match(/(\$__timeGroupAlias\(([\w._]+,)).*?(?=\))/g)
       : q.match(/(\$__timeGroup\(([\w_.]+,)).*?(?=\))/g);
     if (res) {
-      interval[0] = res[0].split(",")[1];
-      interval[1] = res[0].split(",")[2];
+      interval[0] = res[0].split(",")[1] ? res[0].split(",")[1].trim() : res[0].split(",")[1];
+      interval[1] = res[0].split(",")[2] ? res[0].split(",")[2].trim() : res[0].split(",")[2];
     }
     return interval;
   }


### PR DESCRIPTION
**What this PR does**: Add support for extra space in argument (function `$__timeGroup` and `$__timeGroupAlias`. No one will lose time with invalid query and add consistency with other similar function from official datasource

**Which issue(s) this PR fixes**: #196 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #196 

**Release note**:
<!--
If this is a user facing change and should be mentioned in release note add it below. If no, just write "NONE" below.
-->
```release-note
NONE
```
