### PR TITLE
fix new time series for every metric and value row name

### DIFF
--- a/src/response_parser.ts
+++ b/src/response_parser.ts
@@ -179,17 +179,23 @@ export default class ResponseParser {
 
   private static _buildDataPoints(results, timeIndex, metricIndex, valueIndexes) {
     const data = [];
+    let targetName = "";
     let metricName = "";
     let i;
     for (const row of results.rows) {
       if (row) {
         for (i = 0; i < valueIndexes.length; i++) {
           const epoch = Number(row.f[timeIndex].v) * 1000;
+          const valueIndexName = results.schema.fields[valueIndexes[i]].name;
+          targetName =
+            metricIndex > -1
+              ? (row.f[metricIndex].v).concat(" ", valueIndexName)
+              : valueIndexName;
           metricName =
             metricIndex > -1
               ? row.f[metricIndex].v
-              : results.schema.fields[valueIndexes[i]].name;
-          const bucket = ResponseParser.findOrCreateBucket(data, metricName);
+              : valueIndexName;
+          const bucket = ResponseParser.findOrCreateBucket(data, targetName, metricName);
           bucket.datapoints.push([Number(row.f[valueIndexes[i]].v), epoch]);
         }
       }
@@ -197,10 +203,10 @@ export default class ResponseParser {
     return data;
   }
 
-  private static findOrCreateBucket(data, target): IDataTarget {
+  private static findOrCreateBucket(data, target, metric): IDataTarget {
     let dataTarget = _.find(data, ["target", target]);
     if (!dataTarget) {
-      dataTarget = { target, datapoints: [], refId: "", query: "" };
+      dataTarget = { target, datapoints: [], refId: metric, query: "" };
       data.push(dataTarget);
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/doitintl/bigquery-grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If the PR is unfinished, mark it as a draft PR.
4. Rebase your PR if it gets out of sync with master
-->

**What this PR does / why we need it**:
Queries with a metric and multiple value rows selected
will generate a time series for every metric/valueName combination.

Example:
```sql
SELECT
  axis AS metric,
  axisCurrent AS current,
  axisVoltage AS voltage
...
```
Will generate a time series/target for every combination:
 - axis contians (`X`, `Y`)
 - time series: `X current`, `X voltage`, `Y current`, `Y voltage`

Similar behavior like MySQL data source.
Tested with: grafana-plotly-panel

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #202

**Special notes for your reviewer**:

**Release note**:
<!--
If this is a user facing change and should be mentioned in release note add it below. If no, just write "NONE" below.
-->
```release-note

```
