### PR TITLE
Modify URL to BigQuery API

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To authenticate with the BigQuery API, you need to create a Google Cloud Platfor
 
 #### Enable APIs
 
-Go to [BigQuery API](https://console.cloud.google.com/apis/library/bigquery-json.googleapis.com) and `Enable` the API:
+Go to [BigQuery API](https://console.cloud.google.com/apis/library/bigquery.googleapis.com) and `Enable` the API:
 
 ![Enable GCP APIs](https://raw.githubusercontent.com/doitintl/bigquery-grafana/master/img/bigquery_enable_api.png)
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -87,7 +87,7 @@ To authenticate with the BigQuery API, you need to create a Google Cloud Platfor
 
 #### Enable APIs
 
-Go to [BigQuery API](https://console.cloud.google.com/apis/library/bigquery-json.googleapis.com) and `Enable` the API:
+Go to [BigQuery API](https://console.cloud.google.com/apis/library/bigquery.googleapis.com) and `Enable` the API:
 
 ![Enable GCP APIs](https://raw.githubusercontent.com/doitintl/bigquery-grafana/master/img/bigquery_enable_api.png)
 

--- a/dist/partials/config.html
+++ b/dist/partials/config.html
@@ -13,7 +13,7 @@
 		</p>
 		<p>
 			The <strong>BigQuery Data Viewer</strong> role provides all the permissions that Grafana needs. The following API
-			needs to be enabled on GCP for the datasource to work: <a class="external-link" target="_blank" href="https://console.cloud.google.com/apis/library/bigquery-json.googleapis.com">BigQuery
+			needs to be enabled on GCP for the datasource to work: <a class="external-link" target="_blank" href="https://console.cloud.google.com/apis/library/bigquery.googleapis.com">BigQuery
 			API</a>
 		</p>
 

--- a/src/partials/config.html
+++ b/src/partials/config.html
@@ -13,7 +13,7 @@
 		</p>
 		<p>
 			The <strong>BigQuery Data Viewer</strong> role provides all the permissions that Grafana needs. The following API
-			needs to be enabled on GCP for the datasource to work: <a class="external-link" target="_blank" href="https://console.cloud.google.com/apis/library/bigquery-json.googleapis.com">BigQuery
+			needs to be enabled on GCP for the datasource to work: <a class="external-link" target="_blank" href="https://console.cloud.google.com/apis/library/bigquery.googleapis.com">BigQuery
 			API</a>
 		</p>
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The URL in the README/docs currently does not work because of changes on GCP - https://cloud.google.com/bigquery/docs/release-notes#October_23_2019.
**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--
If this is a user facing change and should be mentioned in release note add it below. If no, just write "NONE" below.
-->
```release-note
NONE
```
