### PR TITLE
Math.round causes overflow in timegroups, we should ceil instead

### DIFF
--- a/src/bigquery_query.ts
+++ b/src/bigquery_query.ts
@@ -693,7 +693,7 @@ export default class BigQueryQuery {
     const seconds =
       (this.templateSrv.timeRange.to._d - this.templateSrv.timeRange.from._d) /
       1000;
-    return Math.round(seconds / options.maxDataPoints) + "s";
+    return Math.ceil(seconds / options.maxDataPoints) + "s";
   }
   private _getDateRangePart(part) {
     if (this.target.timeColumnType === "DATE") {

--- a/src/specs/bigquery_query.test.ts
+++ b/src/specs/bigquery_query.test.ts
@@ -331,6 +331,15 @@ describe("BigQueryQuery", () => {
       where: []
     };
     const query = new BigQueryQuery(target, templateSrv);
+    const time = {
+      from: { _d: 1588147101364 },
+      to: { _d: 1588148901364 }
+    };
+    query.templateSrv.timeRange = time;
+ 
+    expect(query.getIntervalStr("auto", undefined, { maxDataPoints: 1742 })).toBe(
+      "TIMESTAMP_SECONDS(DIV(UNIX_SECONDS(`my_data`), 2) * 2) AS time"
+    );
     expect(query.getIntervalStr("1s", "0", null)).toBe(
       "TIMESTAMP_SECONDS(DIV(UNIX_SECONDS(`my_data`), 1) * 1) AS time"
     );


### PR DESCRIPTION
**What this PR does / why we need it**:

Make sure graphs are full of data when using auto interval calculations 

**Which issue(s) this PR fixes**:

Fixes #235 

**Special notes for your reviewer**:

**Release note**:
<!--
If this is a user facing change and should be mentioned in release note add it below. If no, just write "NONE" below.
-->
```release-note

```
