### PR TITLE
Allow auto calculated limit to be inserted a specific place instead of just appended to the end

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -528,7 +528,14 @@ export class BigQueryDatasource {
     }
     const limit = q.match(/[^]+(\bLIMIT\b)/gi);
     if (limit == null) {
-      q += " LIMIT " + options.maxDataPoints;
+      const limitStatement = " LIMIT " + options.maxDataPoints;
+      const limitPosition = q.match(/\$__limitPosition/g); 
+      if (limitPosition !== null)
+      { 
+        q = q.replace(/\$__limitPosition/g, limitStatement);
+      } else {
+        q += limitStatement;
+      }
     }
     return q;
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #232 

**Special notes for your reviewer**:

**Release note**:
<!--
If this is a user facing change and should be mentioned in release note add it below. If no, just write "NONE" below.
-->
```release-note
This allows the user to specify where the LIMIT statement should be inserted when using $__timeGroup(..., auto).

Use $__limitPosition to specify if the limit should be inserted to a specific placement rather than the default behaviour of appending to the end of the query.
```
