### PR TITLE
Fixes: #277 Update dataset locations list to include all currently supported BigQuery dataset locations

### DIFF
--- a/src/config_ctrl.ts
+++ b/src/config_ctrl.ts
@@ -47,29 +47,37 @@ export class BigQueryConfigCtrl {
       { key: this.defaultAuthenticationType, value: "Google JWT File" },
       { key: "gce", value: "GCE Default Service Account" }
     ];
+    // GCP Dataset Locations: https://cloud.google.com/bigquery/docs/locations
     this.locations = [
+      // Multi-regional locations
       { text: "United States (US)", value: "US" },
       { text: "European Union (EU)", value: "EU" },
+      // Americas
+      { text: "Las Vegas (us-west4)", value: "us-west4" },
       { text: "Los Angeles (us-west2)", value: "us-west2" },
-      {
-        text: "Montréal (northamerica-northeast1)",
-        value: "northamerica-northeast1"
-      },
-      { text: "South Carolina (us-east1)", value: "us-east1" },
+      { text: "Montréal (northamerica-northeast1)", value: "northamerica-northeast1" },
       { text: "Northern Virginia (us-east4)", value: "us-east4" },
+      { text: "Oregon (us-west1)", value: "us-west1" },
+      { text: "Salt Lake City (us-west3)", value: "us-west3" },
       { text: "São Paulo (southamerica-east1)", value: "southamerica-east1" },
+      { text: "South Carolina (us-east1)", value: "us-east1" },
+      // Europe
+      { text: "Belgium (europe-west1)", value: "europe-west1" },
       { text: "Finland (europe-north1)", value: "europe-north1" },
-      { text: "London (europe-west2)", value: "europe-west2" },
       { text: "Frankfurt (europe-west3)", value: "europe-west3" },
+      { text: "London (europe-west2)", value: "europe-west2" },
+      { text: "Netherlands (europe-west4)", value: "europe-west4" },
       { text: "Zürich (europe-west6)", value: "europe-west6" },
+      // Asia Pacific
       { text: "Hong Kong (asia-east2)", value: "asia-east2" },
+      { text: "Jakarta (asia-southeast2)", value: "asia-southeast2" },
       { text: "Mumbai (asia-south1)", value: "asia-south1" },
       { text: "Osaka (asia-northeast2)", value: "asia-northeast2" },
-      { text: "Taiwan (asia-east1)", value: "asia-east1" },
-      { text: "Tokyo (asia-northeast1)", value: "asia-northeast1" },
+      { text: "Seoul (asia-northeast3)", value: "asia-northeast3" },
       { text: "Singapore (asia-southeast1)", value: "asia-southeast1" },
       { text: "Sydney (australia-southeast1)", value: "australia-southeast1" },
-      { text: "Seoul (asia-northeast3)", value: "asia-northeast3"}
+      { text: "Taiwan (asia-east1)", value: "asia-east1" },
+      { text: "Tokyo (asia-northeast1)", value: "asia-northeast1" }
     ];
     this.queryPriority = [{text:"INTERACTIVE", value: "INTERACTIVE"}, {text:"BATCH", value: "BATCH"}];
   }

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -69,28 +69,37 @@ export class BigQueryQueryCtrl extends QueryCtrl {
       { text: "ASC", value: "1" },
       { text: "DESC", value: "2" }
     ];
+    // GCP Dataset Locations: https://cloud.google.com/bigquery/docs/locations
     this.locations = [
+      // Multi-regional locations
       { text: "United States (US)", value: "US" },
       { text: "European Union (EU)", value: "EU" },
+      // Americas
+      { text: "Las Vegas (us-west4)", value: "us-west4" },
       { text: "Los Angeles (us-west2)", value: "us-west2" },
-      {
-        text: "Montréal (northamerica-northeast1)",
-        value: "northamerica-northeast1"
-      },
-      { text: "South Carolina (us-east1)", value: "us-east1" },
+      { text: "Montréal (northamerica-northeast1)", value: "northamerica-northeast1" },
       { text: "Northern Virginia (us-east4)", value: "us-east4" },
+      { text: "Oregon (us-west1)", value: "us-west1" },
+      { text: "Salt Lake City (us-west3)", value: "us-west3" },
       { text: "São Paulo (southamerica-east1)", value: "southamerica-east1" },
+      { text: "South Carolina (us-east1)", value: "us-east1" },
+      // Europe
+      { text: "Belgium (europe-west1)", value: "europe-west1" },
       { text: "Finland (europe-north1)", value: "europe-north1" },
-      { text: "London (europe-west2)", value: "europe-west2" },
       { text: "Frankfurt (europe-west3)", value: "europe-west3" },
+      { text: "London (europe-west2)", value: "europe-west2" },
+      { text: "Netherlands (europe-west4)", value: "europe-west4" },
       { text: "Zürich (europe-west6)", value: "europe-west6" },
+      // Asia Pacific
       { text: "Hong Kong (asia-east2)", value: "asia-east2" },
+      { text: "Jakarta (asia-southeast2)", value: "asia-southeast2" },
       { text: "Mumbai (asia-south1)", value: "asia-south1" },
       { text: "Osaka (asia-northeast2)", value: "asia-northeast2" },
-      { text: "Taiwan (asia-east1)", value: "asia-east1" },
-      { text: "Tokyo (asia-northeast1)", value: "asia-northeast1" },
+      { text: "Seoul (asia-northeast3)", value: "asia-northeast3" },
       { text: "Singapore (asia-southeast1)", value: "asia-southeast1" },
-      { text: "Sydney (australia-southeast1)", value: "australia-southeast1" }
+      { text: "Sydney (australia-southeast1)", value: "australia-southeast1" },
+      { text: "Taiwan (asia-east1)", value: "asia-east1" },
+      { text: "Tokyo (asia-northeast1)", value: "asia-northeast1" }
     ];
     if (!this.target.rawSql) {
       // special handling when in table panel


### PR DESCRIPTION
**What this PR does / why we need it**:

These changes update the list of possible dataset locations to include all currently supported locations as documented here: https://cloud.google.com/bigquery/docs/locations#supported_regions .

**Which issue(s) this PR fixes**:

Fixes #277 

**Special notes for your reviewer**:

None

**Release note**:
<!--
If this is a user facing change and should be mentioned in release note add it below. If no, just write "NONE" below.
-->
```
Update dataset locations list to include all currently supported BigQuery dataset locations
```
