### PR TITLE
Update helm install instructions to use 2.0.0

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,11 @@ Add the below to your values.yaml
 ## Pass the plugins you want installed as a list.
 ##
 plugins:
-  - https://github.com/doitintl/bigquery-grafana/archive/1.0.8.zip;doit-bigquery-datasource
+  - https://github.com/doitintl/bigquery-grafana/archive/2.0.0.zip;doit-bigquery-datasource
+
+grafana.ini:
+  plugins:
+    allow_loading_unsigned_plugins: doitintl-bigquery-datasource
 ...
 ```
 


### PR DESCRIPTION
Updates install directions per this comment. I thought about updating the cli instructions to use 2.0.0 rather than 1.0.8, but I haven't actually tested that to work. https://github.com/doitintl/bigquery-grafana/issues/255#issuecomment-661720241