### PR TITLE
modify args of logger so that it follows key/value pairs（Fixes #303 partially）

### DIFF
--- a/pkg/plugin.go
+++ b/pkg/plugin.go
@@ -110,7 +110,7 @@ func (td *SampleDatasource) query(ctx context.Context, query backend.DataQuery) 
 
 	rows, err := BigQueryRun(ctx, qm)
 	if err != nil {
-		log.DefaultLogger.Error("query BigQueryRun error %v", err)
+		log.DefaultLogger.Error("query BigQueryRun error", "Error", err)
 	}
 	// Log a warning if `Format` is empty.
 	if qm.Format == "" {
@@ -184,16 +184,16 @@ func BigQueryRun(ctx context.Context, query queryModel) (*TransformedResults, er
 	job, err := q.Run(ctx)
 
 	if err != nil {
-		log.DefaultLogger.Info("Query run error: %v\n", err)
+		log.DefaultLogger.Info("Query run error", "Error", err)
 		return nil, err
 	}
 	status, err := job.Wait(ctx)
 	if err != nil {
-		log.DefaultLogger.Info("Query wait", "error: %v\n", err)
+		log.DefaultLogger.Info("Query wait", "Error", err)
 		return nil, err
 	}
 	if err := status.Err(); err != nil {
-		log.DefaultLogger.Info("Query status error: %v\n", err)
+		log.DefaultLogger.Info("Query status error", "Error", err)
 		return nil, err
 	}
 	it, err := job.Read(ctx)


### PR DESCRIPTION
This PR includes "Fixes #303 (Partially)".

As I said in #303, when an error occurs in `pkg/plugin.go`, `err` object isn't expanded to `%v`. So I can't see detail error.

Example:
https://github.com/doitintl/bigquery-grafana/blob/756780ef960c21df941467e597e642a47d5a53f0/pkg/plugin.go#L187
```
t=2021-01-06T11:53:01+0000 lvl=info msg="Query run error: %v\n" logger=plugins.backend pluginId=doitintl-bigquery-datasource
```

Logger in `github.com/grafana/grafana-plugin-sdk-go/backend/log` uses `go-hclog`(https://github.com/hashicorp/go-hclog). From README in `go-hclog`, args of logger should be specified as key/value pair.
https://github.com/hashicorp/go-hclog#emit-an-info-level-message-with-2-keyvalue-pairs

So I have modified args and confirmed `err` is expanded.

```
t=2021-01-08T00:34:22+0000 lvl=info msg="Query run error" logger=plugins.backend pluginId=doitintl-bigquery-datasource Error="googleapi: Error 404: Not found: Project a, notFound"
```

Would you check codes that I have modified? Thank you for looking my PR!