### PR TITLE
Use getTime for UTC conversion

### DIFF
--- a/src/bigquery_query.ts
+++ b/src/bigquery_query.ts
@@ -89,9 +89,6 @@ export default class BigQueryQuery {
   public static replaceTimeShift(q) {
     return q.replace(/(\$__timeShifting\().*?(?=\))./g, '');
   }
-  static convertToUtc(d) {
-    return new Date(d.getTime() + d.getTimezoneOffset() * 60000);
-  }
 
   public target: any;
   public templateSrv: any;
@@ -545,13 +542,11 @@ export default class BigQueryQuery {
     let fromD = options.range.from;
     let toD = options.range.to;
     if (this.target.convertToUTC === true) {
-      fromD = BigQueryQuery.convertToUtc(options.range.from._d);
-      toD = BigQueryQuery.convertToUtc(options.range.to._d);
+      fromD = options.range.from._d.getTime();
+      toD = options.range.to._d.getTime();
     }
-    let to = '';
-    let from = '';
-    from = this._getDateRangePart(fromD);
-    to = this._getDateRangePart(toD);
+    let from = this._getDateRangePart(fromD);
+    let to = this._getDateRangePart(toD);
     if (this.target.timeColumn === '-- time --') {
       const myRegexp = /\$__timeFilter\(([\w_.]+)\)/g;
       const tf = myRegexp.exec(q);

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -482,8 +482,8 @@ export class BigQueryDatasource {
   private setUpPartition(query, isPartitioned, partitionedField, options) {
     partitionedField = partitionedField ? partitionedField : '_PARTITIONTIME';
     if (isPartitioned && !query.match(partitionedField)) {
-      const fromD = BigQueryQuery.convertToUtc(options.range.from._d);
-      const toD = BigQueryQuery.convertToUtc(options.range.to._d);
+      const fromD = options.range.from._d.getTime();
+      const toD = options.range.to._d.getTime();
       const from = `${partitionedField} >= '${BigQueryQuery.formatDateToString(fromD, '-', true)}'`;
       const to = `${partitionedField} < '${BigQueryQuery.formatDateToString(toD, '-', true)}'`;
       const partition = `where ${from} AND ${to} AND `;


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the convertToUTC function by using `Date.prototype.getTime()`, which returns a UTC time.

**Which issue(s) this PR fixes**:
Fixes #307

**Special notes for your reviewer**:

I removed the convertToUTC function completely and replaced with the builtin `getTime()` which returns a UTC time already.

**Release note**:

```release-note
If using a TIMESTAMP column along with the Convert to UTC option, along with a time shift, data may now be shifted incorrectly
```
