### PR TITLE
Check for timeColumn matches partitioned column

### DIFF
--- a/src/bigquery_query.ts
+++ b/src/bigquery_query.ts
@@ -390,21 +390,25 @@ export default class BigQueryQuery {
     });
     if (this.target.partitioned) {
       const partitionedField = this.target.partitionedField ? this.target.partitionedField : '_PARTITIONTIME';
-      if (this.templateSrv.timeRange && this.templateSrv.timeRange.from) {
-        const from = `${partitionedField} >= '${BigQueryQuery.formatDateToString(
-          this.templateSrv.timeRange.from._d,
-          '-',
-          true
-        )}'`;
-        conditions.push(from);
-      }
-      if (this.templateSrv.timeRange && this.templateSrv.timeRange.to) {
-        const to = `${partitionedField} < '${BigQueryQuery.formatDateToString(
-          this.templateSrv.timeRange.to._d,
-          '-',
-          true
-        )}'`;
-        conditions.push(to);
+      if (this.target.timeColumn !== partitionedField) {
+        if (this.templateSrv.timeRange && this.templateSrv.timeRange.from) {
+          let fromD = this.templateSrv.timeRange.from;
+          const from = `${partitionedField} >= '${BigQueryQuery.formatDateToString(
+              fromD._d,
+              '-',
+              true
+          )}'`;
+          conditions.push(from);
+        }
+        if (this.templateSrv.timeRange && this.templateSrv.timeRange.to) {
+          let toD = this.templateSrv.timeRange.to;
+          const to = `${partitionedField} < '${BigQueryQuery.formatDateToString(
+              toD._d,
+              '-',
+              true
+          )}'`;
+          conditions.push(to);
+        }
       }
     }
     if (this.target.sharded) {


### PR DESCRIPTION
When using the same time column as a partitioned column it results in
having the time column appear twice in the resulting query

**What this PR does / why we need it**:

When appending the partition clause, ensure that it is not the time column.

**Which issue(s) this PR fixes**:

Fixes #309 

**Special notes for your reviewer**:

**Release note**:

```release-note
When using a TIMESTAMP partitioned column, the generated queries will only include a single clause
```
