### PR TITLE
Force Date format in where clause on partitionned field

### DIFF
--- a/src/bigquery_query.ts
+++ b/src/bigquery_query.ts
@@ -392,19 +392,19 @@ export default class BigQueryQuery {
       const partitionedField = this.target.partitionedField ? this.target.partitionedField : '_PARTITIONTIME';
       if (this.target.timeColumn !== partitionedField) {
         if (this.templateSrv.timeRange && this.templateSrv.timeRange.from) {
-          const from = `${partitionedField} >= '${BigQueryQuery.formatDateToString(
+          const from = `${partitionedField} >= DATE('${BigQueryQuery.formatDateToString(
             this.templateSrv.timeRange.from._d,
             '-',
             true
-          )}'`;
+          )}')`;
           conditions.push(from);
         }
         if (this.templateSrv.timeRange && this.templateSrv.timeRange.to) {
-          const to = `${partitionedField} < '${BigQueryQuery.formatDateToString(
+          const to = `${partitionedField} < DATE('${BigQueryQuery.formatDateToString(
             this.templateSrv.timeRange.to._d,
             '-',
             true
-          )}'`;
+          )}')`;
           conditions.push(to);
         }
       }


### PR DESCRIPTION
When a table is partitioned, the WHERE clause 

```
partitionedField > '2021-05-04 10:07:11' AND partitionedField < '2021-06-03 10:07:11'
```

is systematically added. resulting with an error : `Could not cast literal "2021-05-04 10:07:11" to type DATE at [10:18]`

This PR force the format of the date field 

```
partitionedField > DATE('2021-05-04 10:07:11') AND partitionedField < DATE('2021-06-03 10:07:11')
```

So the partionedField condition is still present, but the request works.

Fixes #334, #309

**Release note**:

```release-note
bug fix on partioned field where clause.
```
