### PR TITLE
allow plugin to be used on grafana greater or equal to 7.0.0

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -9,7 +9,7 @@
   "backend": true,
   "executable": "doitintl-bigquery-datasource",
   "dependencies": {
-    "grafanaDependency": ">=7.0.0"
+    "grafanaDependency": "7.x || 8.x"
   },
   "queryOptions": {
     "maxDataPoints": true

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -9,7 +9,7 @@
   "backend": true,
   "executable": "doitintl-bigquery-datasource",
   "dependencies": {
-    "grafanaDependency": "7.x.x"
+    "grafanaDependency": ">=7.0.0"
   },
   "queryOptions": {
     "maxDataPoints": true


### PR DESCRIPTION
**What this PR does / why we need it**:

To run the plugin on Grafana 8.0 and above

**Which issue(s) this PR fixes**:

Fixes https://github.com/doitintl/bigquery-grafana/issues/341

**Special notes for your reviewer**:

**Release note**:

```release-note
Allows plugin to be used on grafana 8.x
```
