### PR TITLE
ResponseParser: Do not conver null values to 0

### DIFF
--- a/src/response_parser.ts
+++ b/src/response_parser.ts
@@ -172,7 +172,8 @@ export default class ResponseParser {
             targetName = metricName;
           }
           const bucket = ResponseParser.findOrCreateBucket(data, targetName, metricName);
-          bucket.datapoints.push([Number(row.f[valueIndexes[i]].v), epoch]);
+          const value = row.f[valueIndexes[i]].v === null ? null : Number(row.f[valueIndexes[i]].v)
+          bucket.datapoints.push([value, epoch]);
         }
       }
     }

--- a/src/specs/datasource.test.ts
+++ b/src/specs/datasource.test.ts
@@ -1097,7 +1097,7 @@ describe('BigQueryDatasource', () => {
               v: '1.521578851E9',
             },
             {
-              v: '37.7753058',
+              v: null,
             },
           ],
         },
@@ -1130,7 +1130,7 @@ describe('BigQueryDatasource', () => {
     results = ResponseParser.parseDataQuery(response, 'time_series');
     it('should return a time_series', () => {
       expect(results[0].datapoints.length).toBe(3);
-      expect(results[0].datapoints[0][0]).toBe(37.7753058);
+      expect(results[0].datapoints[0][0]).toBe(null);
       expect(results[0].datapoints[0][1]).toBe(1521578851000);
       expect(results[0].datapoints[2][0]).toBe(37.781752);
       expect(results[0].datapoints[2][1]).toBe(1521578927000);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/doitintl/bigquery-grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If the PR is unfinished, mark it as a draft PR.
4. Rebase your PR if it gets out of sync with master
-->

**What this PR does / why we need it**:

At Grafana we got the following issue reported: https://github.com/grafana/grafana/issues/35899

I believe it's related to the way you folks handle null values when parsing the response. All null values are parsed as 0 due to the casting [here](https://github.com/doitintl/bigquery-grafana/blob/36255f29a909466539fafcd5a9de828c94ef7beb/src/response_parser.ts#L174)

**Which issue(s) this PR fixes**:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/grafana/grafana/issues/35899
