### PR TITLE
add support for "is", "is not" bigquery operators

### DIFF
--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -662,7 +662,19 @@ export class BigQueryQueryCtrl extends QueryCtrl {
             return this.$q.when([]);
           case 'op':
             return this.$q.when(
-              this.uiSegmentSrv.newOperators(['=', '!=', '<', '<=', '>', '>=', 'IN', 'LIKE', 'NOT LIKE'])
+              this.uiSegmentSrv.newOperators([
+                '=',
+                '!=',
+                '<',
+                '<=',
+                '>',
+                '>=',
+                'IN',
+                'LIKE',
+                'NOT LIKE',
+                'IS',
+                'IS NOT',
+              ])
             );
           default:
             return this.$q.when([]);


### PR DESCRIPTION
<img width="525" alt="Screen Shot 2021-07-11 at 12 43 29 PM" src="https://user-images.githubusercontent.com/909721/125208152-a8f23b00-e245-11eb-8a12-0a646cfbbf88.png">

Adds support for "IS" and "IS NOT" Google BigQuery opetorators. 

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/doitintl/bigquery-grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If the PR is unfinished, mark it as a draft PR.
4. Rebase your PR if it gets out of sync with master
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
This allows filtering out rows with null values for a column. I was running into issues rendering a table when a metric column value was null.
<img width="655" alt="Screen Shot 2021-07-11 at 1 35 23 PM" src="https://user-images.githubusercontent.com/909721/125209350-faea8f00-e24c-11eb-8046-d77856b5dc46.png">


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

**Release note**:

<!--
If this is a user facing change and should be mentioned in release note add it below. If no, just write "NONE" below.
-->

```release-note

```
