### PR TITLE
Remove dependency on superquery-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "license": "MIT",
   "dependencies": {
     "@grafana/toolkit": "^7.3.4",
-    "@superquery/superquery-lib": "^1.3.4",
     "@types/node": "^11.11.1",
     "brace": "^0.10.0",
     "codecov": "^3.2.0",


### PR DESCRIPTION
The actual code dependency has been removed previously, this is just a remaining cleanup.

**What this PR does / why we need it**:

This is remaining part for https://github.com/doitintl/bigquery-grafana/issues/340
npm still depends on private `superquery-lib`, this PR removes this reference allowing contributors to build, run, test code locally.

**Which issue(s) this PR fixes**:

https://github.com/doitintl/bigquery-grafana/issues/340
