### PR TITLE
apply instance settings properties to datasource instance

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -162,24 +162,31 @@ export class BigQueryDatasource {
   }
   public authenticationType: string;
   public projectName: string;
-  private readonly id: any;
+  public readonly name: string;
+  public readonly id: number;
+  public readonly type: string;
+  public readonly uid: string;
+  private readonly url: string;
+  private readonly baseUrl: string;
   private jsonData: any;
   private responseParser: ResponseParser;
   private queryModel: BigQueryQuery;
-  private readonly baseUrl: string;
-  private readonly url: string;
   private runInProject: string;
   private processingLocation: string;
   private queryPriority: string;
 
   /** @ngInject */
   constructor(instanceSettings, private backendSrv, private $q, private templateSrv) {
+    this.name = instanceSettings.name;
     this.id = instanceSettings.id;
+    this.type = instanceSettings.type;
+    this.uid = instanceSettings.uid;
+    this.url = instanceSettings.url;
     this.jsonData = instanceSettings.jsonData;
+    this.baseUrl = `/bigquery/`;
+
     this.responseParser = new ResponseParser(this.$q);
     this.queryModel = new BigQueryQuery({});
-    this.baseUrl = `/bigquery/`;
-    this.url = instanceSettings.url;
     this.authenticationType = instanceSettings.jsonData.authenticationType || 'jwt';
     (async () => {
       this.projectName = instanceSettings.jsonData.defaultProject || (await this.getDefaultProject());


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the constructor of the datasource to apply a few required properties from the `instanceSettings` to the datasource instance itself; specifically: `name`, `type`, and `uid`.

These properties are required and assumed to be present in grafana code. Selecting and using the datasource does not work correctly without them. It's kind of hard to trace all of the places where they are referenced, but a couple examples:

- They are defined in the types ([code](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/datasource.ts#L178-L196))
- Legacy datasource code examples apply these properties ([code](https://github.com/grafana/simple-json-backend-datasource/blob/master/src/datasource.ts#L39-L42))
- `uid` is referenced to write last-used datasource to localstorage ([code](https://github.com/grafana/grafana/blob/main/public/app/features/explore/state/utils.ts#L105)), `name` is referenced a bunch in explore utils ([code](https://github.com/grafana/grafana/blob/main/public/app/core/utils/explore.ts)), in ui to drive the datasource picker ([code](https://github.com/grafana/grafana/blob/main/public/app/features/explore/ExploreToolbar.tsx#L233)), etc...


Before:

https://user-images.githubusercontent.com/918178/137183191-7191baa8-5d4e-41b5-b639-c6491e4e7997.mp4

After:

https://user-images.githubusercontent.com/918178/139126854-8a8182fa-e55f-487a-bd7c-c08dd4ea8fc7.mov

**Which issue(s) this PR fixes**:

Fixes #382

**Special notes for your reviewer**:

**Release note**:

```release-note
Fixed an issue where the bigquery datasource could not be selected from the explore view unless it was the default datasource.
```
