### PR TITLE
The plugin is supported by grafana 9

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -9,7 +9,7 @@
   "backend": true,
   "executable": "doitintl-bigquery-datasource",
   "dependencies": {
-    "grafanaDependency": "7.x || 8.x"
+    "grafanaDependency": "7.x || 8.x || 9.x"
   },
   "queryOptions": {
     "maxDataPoints": true


### PR DESCRIPTION
:wave: 

This plugin should work fine on Grafana 9 (main). At least right now :)

Another option would be to set `grafanaDependency` to `>= 7`

Signed-off-by: bergquist <carl.bergquist@gmail.com>
