### PR TITLE
Tidy up the README and clarify project "status"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@
 ![GitHub forks](https://img.shields.io/github/forks/doitintl/bigquery-grafana.svg?style=svg)
 [![Automated Release Notes by gren](https://img.shields.io/badge/%F0%9F%A4%96-release%20notes-00B2EE.svg)](https://github-tools.github.io/github-release-notes/)
 
-## Status: Production Ready
-
 # BigQuery DataSource for Grafana
 
-A BigQuery DataSource plugin provides support for [BigQuery](https://cloud.google.com/bigquery/) as a backend database.
+A production-ready BigQuery DataSource plugin that provides support for [BigQuery](https://cloud.google.com/bigquery/) as a backend database.
 
 ### Quick Start
 
@@ -200,8 +198,8 @@ yarn run test
 
 ## Contributing
 
-See the [Contribution Guide](https://doitintl.github.io/bigquery-grafana/CONTRIBUTING).
+See the [CONTRIBUTING](https://doitintl.github.io/bigquery-grafana/CONTRIBUTING) file.
 
 ## License
 
-See the [License File](https://doitintl.github.io/bigquery-grafana/LICENSE).
+See the [LICENSE](https://doitintl.github.io/bigquery-grafana/LICENSE) file.


### PR DESCRIPTION
The existing "project status" heading could be misunderstood as an indicator of release status. By instead using the phrase "production-ready" as an adjective in the short description, we are being more explicit that "production-ready" refers to the maturity of the codebase.

This change also tidies up the stylization of the CONTRIBUTING and LICENCE links.
